### PR TITLE
fix: don't crash the process if android project doesn't exist

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -106,7 +106,7 @@ export async function downloadProfile(
       .filter(Boolean)
       .join('.');
 
-    if (!packageNameWithSuffix) {
+    if (!packageNameWithSuffix && !local) {
       throw new Error(
         "Failed to retrieve the package name from the project's Android manifest file. Please provide the package name with the --appId flag."
       );

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -127,7 +127,7 @@ export async function downloadProfile(
     logger.info(`File to be pulled: ${file}`);
 
     // If destination path is not specified, pull to the current directory
-    dstPath = dstPath || ctx?.root || './';
+    dstPath = dstPath || ctx?.root || '.';
 
     logger.debug('Internal commands run to pull the file:');
 
@@ -237,7 +237,7 @@ program
 program.parse();
 
 const options = program.opts();
-const dstPath = './';
+const dstPath = '.';
 downloadProfile(
   options.local,
   options.fromDownload,


### PR DESCRIPTION
Before

```bash
/Users/kirylziusko/IdeaProjects/margelo/react-native-release-profiler/lib/commonjs/cli.js:90
      throw new Error("Failed to retrieve the package name from the project's Android manifest file. Please provide the package name with the --appId flag.");
            ^

Error: Failed to retrieve the package name from the project's Android manifest file. Please provide the package name with the --appId flag.
    at downloadProfile (/Users/kirylziusko/IdeaProjects/margelo/react-native-release-profiler/lib/commonjs/cli.js:90:13)
    at process.processTicksAndRejections (node:internal/process/task_queues:95:5)

Node.js v20.14.0
```

After

```bash
info File to be pulled: trace-2024-06-25T08_42_59.123Z.cpuprofile.txt
Getting source maps from Metro packager server
Downloading from http://localhost:8081/index.map?platform=android&dev=true&minify=false
Error: Cannot obtain source maps from Metro packager server
warn Cannot find source maps, running the transformer without it
info Instructions on how to get source maps: set `bundleInDebug: true` in your app/build.gradle file, inside the `project.ext.react` map.
success Successfully converted to Chrome tracing format and pulled the file to ./trace-2024-06-25T08_42_59.123Z.cpuprofile.txt-converted.json
```

Closes https://github.com/margelo/react-native-release-profiler/issues/2