### PR TITLE
fix: match `stopProfiling` signature according to documentation

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -17,10 +17,13 @@ const ReleaseProfiler = NativeModules.ReleaseProfiler
       }
     );
 
-export function startProfiling(): Boolean {
+export function startProfiling(): boolean {
   return ReleaseProfiler.startProfiling();
 }
 
-export function stopProfiling(saveToDownloads = false): Promise<string> {
+export function stopProfiling(
+  saveToDownloads = false,
+  _fileName = ''
+): Promise<string> {
   return ReleaseProfiler.stopProfiling(saveToDownloads);
 }


### PR DESCRIPTION
Currently if we pass `fileName` then TS complains, since it takes a signature of the function from `index.ts` file, and this function "expects 0-1 params".

In this PR I'm fixing this problem by adding `_fileName = ''` param to `stopProfiling` function.

Another minor improvement is the usage of `boolean` instead of `Boolean`.