### PR TITLE
fix: don't throw an error on stderr

### DIFF
--- a/src/getConfig.ts
+++ b/src/getConfig.ts
@@ -29,8 +29,8 @@ function getConfig(): Promise<Config | null> {
       }
 
       if (stderr) {
-        resolve(null);
-        throw new Error(stderr);
+        console.warn("The following problem occured during retrieving the app's config:");
+        console.warn(stderr);
       }
     });
   });

--- a/src/getConfig.ts
+++ b/src/getConfig.ts
@@ -11,7 +11,10 @@ interface Config {
 
 function getConfig(): Promise<Config | null> {
   return new Promise((resolve, reject) => {
-    exec('npx react-native config', (error, stdout, stderr) => {
+    // Get path to react-native binary:
+    const reactNativePath = require.resolve('react-native/cli.js');
+
+    exec(`${reactNativePath} config`, (error, stdout, stderr) => {
       if (error) {
         console.error(`exec error: ${error}`);
         reject(error);
@@ -26,10 +29,16 @@ function getConfig(): Promise<Config | null> {
           `Failed to parse the output of "npx react-native config" to JSON. Are you sure the output returns a JSON-only string?\nError: ${e}`
         );
         reject(e);
+        return;
       }
 
+      // If we get here it means that the config object could be parsed as JSON, so we can assume
+      // that loading the config went fine. We still want to inform about any warnings or errors
+      // that might have occured along the way:
       if (stderr) {
-        console.warn("The following problem occured during retrieving the app's config:");
+        console.warn(
+          "The following problem occured during retrieving the app's config:"
+        );
         console.warn(stderr);
       }
     });


### PR DESCRIPTION
When running release profiler i was getting errors because there was a mismatch between the react native version when it tries to run `npx react-native` (the cli tool prints a warning, which is in stderr in which case our lib fails and throws an error):



![CleanShot 2024-11-22 at 17 41 02](https://github.com/user-attachments/assets/7980f32b-e2c2-4bf4-9157-381937d3b63d)

i fixed this by:

- not using npx but resolve the path to the cli manually, this way we can be sure to always use the react native version bundled with the app
- if we were able to parse the config there is no need to throw an error, we can just print it as warning 