### PR TITLE
chore: add expo instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,14 @@ yarn add react-native-release-profiler
 cd ios && pod install
 ```
 
+### Expo
+
+Expo requires you to also install @react-native-community/cli
+
+```sh
+yarn add --dev @react-native-community/cli
+```
+
 ## Usage
 
 1. Install **react-native-release-profiler**


### PR DESCRIPTION
Trivial addition of instructions for usage with Expo. 

When running the release profiler to retrieve the sample we see the following:

```sh

> latestexpo@1.0.0 android:profile
> npx react-native-release-profiler --fromDownload --appId com.andreixoc.LatestExpo

node:internal/modules/cjs/loader:1051
  throw err;
  ^

Error: Cannot find module '@react-native-community/cli-tools'
Require stack:
- /Users/andreicalazans/dev/LatestExpo/node_modules/react-native-release-profiler/lib/commonjs/cli.js
    at Module._resolveFilename (node:internal/modules/cjs/loader:1048:15)
    at Module._load (node:internal/modules/cjs/loader:901:27)
    at Module.require (node:internal/modules/cjs/loader:1115:19)
    at require (node:internal/modules/helpers:130:18)
    at Object.<anonymous> (/Users/andreicalazans/dev/LatestExpo/node_modules/react-native-release-profiler/lib/commonjs/cli.js:8:17)
    at Module._compile (node:internal/modules/cjs/loader:1241:14)
    at Module._extensions..js (node:internal/modules/cjs/loader:1295:10)
    at Module.load (node:internal/modules/cjs/loader:1091:32)
    at Module._load (node:internal/modules/cjs/loader:938:12)
    at Function.executeUserEntryPoint [as runMain] (node:internal/modules/run_main:83:12) {
  code: 'MODULE_NOT_FOUND',
  requireStack: [
    '/Users/andreicalazans/dev/LatestExpo/node_modules/react-native-release-profiler/lib/commonjs/cli.js'
  ]
}
```