### PR TITLE
fix: iOS build error on React Native v0.81

### DIFF
--- a/ios/ReleaseProfiler.mm
+++ b/ios/ReleaseProfiler.mm
@@ -1,10 +1,18 @@
 #import <React/RCTBridgeModule.h>
 #import <hermes/hermes.h>
-#include <React/ReactNativeVersion.h>
 
+#ifdef __has_include
+#if __has_include(<React/ReactNativeVersion.h>)
+#include <React/ReactNativeVersion.h>
 #define IS_RN_VERSION_0_81_OR_HIGHER                                           \
   (REACT_NATIVE_VERSION_MAJOR > 0 ||                                           \
    (REACT_NATIVE_VERSION_MAJOR == 0 && REACT_NATIVE_VERSION_MINOR >= 81))
+#else
+#define IS_RN_VERSION_0_81_OR_HIGHER false
+#endif
+#else
+#define IS_RN_VERSION_0_81_OR_HIGHER false
+#endif
 
 #if IS_RN_VERSION_0_81_OR_HIGHER
 using namespace facebook::hermes;


### PR DESCRIPTION
While migrating Expensify/App to the newest React Native version (v0.81), I got a build issue where `react-native-release-profiler` couldn't find `enableSamplingProfiler`

It turned out that we should use the new approach (`IHermesRootAPI`) to access the functions
```objective-c++
IHermesRootAPI *api = castInterface<IHermesRootAPI>(makeHermesRootAPI());
api->enableSamplingProfiler();
```

Unfortunately, I wasn't able to build the example app due to some issues with pods (I followed the CONTRIBUTING.md file), so I'd appreciate some help 🙏 

cc @chrispader as you're actively working on the Expensify/App